### PR TITLE
Non client destruction

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "webtorrent extension"
   ],
   "engines": {
-    "node": "10.16.0"
+    "node": "^10.16.0"
   },  
   "main": "src/index.js",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ const progressLogger = (logger, status, setStatus) => (torrent = initialState, a
       numPeers: torrent.numPeers
     })
 
-    if (torrentIsDone && torrrentFile.done && !torrent.created) {
+    if (torrentIsDone && !torrent.created && torrrentFile && torrrentFile.done) {
       torrrentFile.getBlobURL((err, url) => {
         setStatus(Object.assign(initialState, { url, filename: torrrentFile.name }));
       });

--- a/src/index.js
+++ b/src/index.js
@@ -47,11 +47,7 @@ const upload = (client, files, setMagnet, progressLogger, setAllowedPeers) => {
 
 const download = (client, torrentOrigin, progressLogger, setClient) => {
   var torrentId = torrentOrigin || "https://webtorrent.io/torrents/sintel.torrent";
-  client.on(ClientEvents.CLIENT_RESET, (newClient, torrent) => {
-    setClient(newClient)
-    progressLogger(torrent, "Leeching");
-  })
-
+  client.on(ClientEvents.CLIENT_RESET, torrent => progressLogger(torrent, "Leeching"));
   client.add(torrentId, torrent => progressLogger(torrent, "Leeching"));
 };
 


### PR DESCRIPTION
## A little context:
- Previously, when the seeder, after blocking access to the leecher on an active connection, granted access for the leecher to download a file, the action flow was:
 - **Seeder**:
     - send a message telling the leecher that it has access.
     - wait for requests
- **Leecher**:
     - receive the message
     - save the torrent magnet URI
     - destroy the webtorrent client instance
     - create a new one
     - start again the download from the beginning

## What does this PR do
This PR improves the flow of the resumed access so that, upon resumed access, the leecher client doesn't have to be destroyed for the download to start again.

 - **Seeder**:
     - send a message telling the leecher that it has access.
     - wait for requests
- **Leecher**
     - receive the message
     - clears the reservation for the pieces (that were blocked when the seeder blocked the leecher) and the queue of pending requests.
     - resumes the download

This is a much **much** better approach for the resumed download action flow. The previous solution was a _functional, but ugly_ one.

> There's still room for improvement, as once the access is granted (or re-granted) all non-downloaded file pieces of the leecher client are cleared, so that they can be re-requested later. I believe that a better solution could be found so that, on big files, the client doesn't have to basically update the entire file pieces array.